### PR TITLE
Hotfix: Redis 보안 설정 비활성화

### DIFF
--- a/ansible/roles/redis/templates/redis-controller.yaml
+++ b/ansible/roles/redis/templates/redis-controller.yaml
@@ -23,6 +23,10 @@ spec:
       containers:
         - name: redis
           image: redis:8.2.1-alpine
+          command:
+            - redis-server
+            - '--protected-mode no'
+            - '--bind 0.0.0.0'
           env:
             - name: TZ
               value: Asia/Seoul

--- a/ansible/roles/redis/templates/redis-master.yaml
+++ b/ansible/roles/redis/templates/redis-master.yaml
@@ -25,6 +25,8 @@ spec:
             - redis-server
             - '--save 60 1'
             - '--loglevel warning'
+            - '--protected-mode no'
+            - '--bind 0.0.0.0'
           env:
             - name: MASTER
               value: 'true'


### PR DESCRIPTION
- redis-master.yaml, redis-controller.yaml에 '--protected-mode no', '--bind 0.0.0.0' 설정 추가